### PR TITLE
Fix building with glib-2.32

### DIFF
--- a/loudmouth/lm-error.c
+++ b/loudmouth/lm-error.c
@@ -25,7 +25,7 @@
  */
 
 #include <config.h>
-#include <glib/gerror.h>
+#include <glib.h>
 #include "lm-error.h"
 
 GQuark


### PR DESCRIPTION
In >=glib-2.31, most glib subheaders cannot be included directly. See
http://git.gnome.org/browse/glib/commit/?id=7455dd370eb37ce3b0b409ff6120501f37b50569
