### PR TITLE
Fix TCP keepalive on OS X 10.9

### DIFF
--- a/loudmouth/lm-sock.c
+++ b/loudmouth/lm-sock.c
@@ -314,6 +314,13 @@ gboolean
 _lm_sock_set_keepalive (LmOldSocketT sock, int delay)
 {
 #ifdef USE_TCP_KEEPALIVES
+
+#ifdef __APPLE__
+#ifndef TCP_KEEPIDLE
+#define TCP_KEEPIDLE TCP_KEEPALIVE
+#endif
+#endif
+
     int opt;
 
     opt = 1;


### PR DESCRIPTION
Mac OS X 10.9 defines TCP_KEEPCNT, which triggers USE_TCP_KEEPALIVES. However, it defines TCP_KEEPALIVE rather than TCP_KEEPIDLE.

Older OS X do not define TCP_KEEPCNT, so this patch is a no-op there.
