### PR TITLE
Make opendir(3) prototypes available

### DIFF
--- a/loudmouth/lm-ssl-gnutls.c
+++ b/loudmouth/lm-ssl-gnutls.c
@@ -24,6 +24,7 @@
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <dirent.h>
 #include <unistd.h>
 #include <glib.h>
 


### PR DESCRIPTION
This fixes the following build issue:

    ../doltcompile gcc -DHAVE_CONFIG_H -I. -I..  -I. -I.. -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include     -DLM_COMPILATION -DRUNTIME_ENDIAN    -g -O2 -Wall -I/usr/include/p11-kit-1   -Wall -Wunused -Wchar-subscripts -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wpointer-arith -Wno-sign-compare -Werror -MT lm-ssl-gnutls.lo -MD -MP -MF .deps/lm-ssl-gnutls.Tpo -c -o lm-ssl-gnutls.lo lm-ssl-gnutls.c
    lm-ssl-gnutls.c: In function '_lm_ssl_set_ca':
    lm-ssl-gnutls.c:213:9: error: unknown type name 'DIR'
    lm-ssl-gnutls.c:216:9: error: implicit declaration of function 'opendir' [-Werror=implicit-function-declaration]
    lm-ssl-gnutls.c:216:9: error: nested extern declaration of 'opendir' [-Werror=nested-externs]
    lm-ssl-gnutls.c:216:18: error: assignment makes pointer from integer without a cast [-Werror]
    lm-ssl-gnutls.c:223:9: error: implicit declaration of function 'readdir' [-Werror=implicit-function-declaration]
    lm-ssl-gnutls.c:223:9: error: nested extern declaration of 'readdir' [-Werror=nested-externs]
    lm-ssl-gnutls.c:223:20: error: assignment makes pointer from integer without a cast [-Werror]
    lm-ssl-gnutls.c:223:58: error: assignment makes pointer from integer without a cast [-Werror]
    lm-ssl-gnutls.c:225:60: error: dereferencing pointer to incomplete type
    lm-ssl-gnutls.c:240:9: error: implicit declaration of function 'closedir' [-Werror=implicit-function-declaration]
    lm-ssl-gnutls.c:240:9: error: nested extern declaration of 'closedir' [-Werror=nested-externs]
    cc1: all warnings being treated as errors
    make[3]: *** [lm-ssl-gnutls.lo] Error 1