### PR TITLE
fix compilation warnings

### DIFF
--- a/loudmouth/lm-debug.h
+++ b/loudmouth/lm-debug.h
@@ -23,18 +23,17 @@
 
 #include <glib.h>
 
-typedef enum {
-    LM_LOG_LEVEL_VERBOSE = 1 << (G_LOG_LEVEL_USER_SHIFT),
-    LM_LOG_LEVEL_NET     = 1 << (G_LOG_LEVEL_USER_SHIFT + 1),
-    LM_LOG_LEVEL_PARSER  = 1 << (G_LOG_LEVEL_USER_SHIFT + 2),
-    LM_LOG_LEVEL_SSL     = 1 << (G_LOG_LEVEL_USER_SHIFT + 3),
-    LM_LOG_LEVEL_SASL    = 1 << (G_LOG_LEVEL_USER_SHIFT + 4),
-    LM_LOG_LEVEL_ALL     = (LM_LOG_LEVEL_NET |
-                            LM_LOG_LEVEL_VERBOSE |
-                            LM_LOG_LEVEL_PARSER |
-                            LM_LOG_LEVEL_SSL |
-                            LM_LOG_LEVEL_SASL)
-} LmLogLevelFlags;
+#define LM_LOG_LEVEL_VERBOSE (1 << (G_LOG_LEVEL_USER_SHIFT))
+#define LM_LOG_LEVEL_NET     (1 << (G_LOG_LEVEL_USER_SHIFT + 1))
+#define LM_LOG_LEVEL_PARSER  (1 << (G_LOG_LEVEL_USER_SHIFT + 2))
+#define LM_LOG_LEVEL_SSL     (1 << (G_LOG_LEVEL_USER_SHIFT + 3))
+#define LM_LOG_LEVEL_SASL    (1 << (G_LOG_LEVEL_USER_SHIFT + 4))
+#define LM_LOG_LEVEL_ALL     (LM_LOG_LEVEL_NET | \
+                              LM_LOG_LEVEL_VERBOSE | \
+                              LM_LOG_LEVEL_PARSER | \
+                              LM_LOG_LEVEL_SSL | \
+                              LM_LOG_LEVEL_SASL)
+typedef GLogLevelFlags LmLogLevelFlags;
 
 #ifndef LM_LOG_DOMAIN
 #  define LM_LOG_DOMAIN "LM"

--- a/loudmouth/lm-old-socket.c
+++ b/loudmouth/lm-old-socket.c
@@ -212,7 +212,7 @@ socket_read_incoming (LmOldSocket *socket,
                                           NULL);
     }
 
-    if (status != G_IO_STATUS_NORMAL || *bytes_read < 0) {
+    if (status != G_IO_STATUS_NORMAL) {
         switch (status) {
         case G_IO_STATUS_EOF:
             *reason = LM_DISCONNECT_REASON_HUP;


### PR DESCRIPTION
* Make LmLogLevelFlags a typedef to GLogLevelFlags to avoid implicit
  casting
* Remove a useless comparison of an unsigned int < 0