### PR TITLE
assorted minor build fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -38,7 +38,7 @@ if test "$os_win32" = "yes"; then
   LDFLAGS="$LDFLAGS -no-undefined"
 fi
 
-AC_PROG_CC
+AC_PROG_CC([cc gcc])
 AC_ISC_POSIX
 AC_HEADER_STDC
 AC_LIBTOOL_WIN32_DLL

--- a/loudmouth/Makefile.am
+++ b/loudmouth/Makefile.am
@@ -111,8 +111,7 @@ libloudmouthinclude_HEADERS =           \
 libloudmouth_1_la_LIBADD =              \
 	$(LOUDMOUTH_LIBS)                   \
 	$(LIBIDN_LIBS)                      \
-	$(ASYNCNS_LIBS)                     \
-	-lresolv
+	$(ASYNCNS_LIBS)
 
 libloudmouth_1_la_LDFLAGS =                                 \
 	-version-info $(LT_CURRENT):$(LT_REVISION):$(LT_AGE)    \

--- a/loudmouth/lm-blocking-resolver.c
+++ b/loudmouth/lm-blocking-resolver.c
@@ -29,6 +29,7 @@
 #include <arpa/nameser_compat.h>
 #endif
 
+#include <netinet/in.h>
 #include <arpa/nameser.h>
 #include <resolv.h>
 

--- a/loudmouth/lm-resolver.c
+++ b/loudmouth/lm-resolver.c
@@ -27,6 +27,7 @@
 #include <arpa/nameser_compat.h>
 #endif
 
+#include <netinet/in.h>
 #include <arpa/nameser.h>
 #include <resolv.h>
 

--- a/loudmouth/lm-sasl.c
+++ b/loudmouth/lm-sasl.c
@@ -25,7 +25,7 @@
 #include <glib.h>
 
 #ifdef HAVE_GSSAPI
-#include <gssapi.h>
+#include <gssapi/gssapi.h>
 #endif
 
 #include "lm-sock.h"

--- a/loudmouth/lm-sha.c
+++ b/loudmouth/lm-sha.c
@@ -75,11 +75,6 @@ extern "C" {
 }
 #endif
 
-#ifndef lint
-static const char rcsid[] =
-"$Id$";
-#endif /* !lint */
-
 #define ROTL(x, n) (((x) << (n)) | ((x) >> (32 - (n))))
 #define ROTR(x, n) (((x) >> (n)) | ((x) << (32 - (n))))
 


### PR DESCRIPTION
5 minimal issues I discovered when trying to build loudmouth on FreeBSD (10.2, amd64).
Tests are still broken for master ('make[2]: "/tmp/lm/build/lm/tests/Makefile" line 478: Could not find ../loudmouth/.deps/lm-data-objects.Po'), but that could be autotools related, still investigating.