### PR TITLE
Include autogen.sh in dist tarball

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,6 +7,7 @@ ACLOCAL_AMFLAGS = -I m4
 
 EXTRA_DIST +=			\
 	loudmouth-1.0.pc.in     \
+	autogen.sh		\
 	README.WIN32
 
 pkgconfig_DATA = loudmouth-1.0.pc


### PR DESCRIPTION
It is convenient to have autogen.sh in the dist tarball in case one
needs to regenerate the build system.