### PR TITLE
GIOCondition is a bit field

### DIFF
--- a/loudmouth/lm-old-socket.c
+++ b/loudmouth/lm-old-socket.c
@@ -517,7 +517,7 @@ socket_connect_cb (GIOChannel   *source,
     /* addr = connect_data->current_addr; */
     fd = g_io_channel_unix_get_fd (source);
 
-    if (condition == G_IO_ERR) {
+    if (condition & G_IO_ERR) {
         len = sizeof (err);
         _lm_sock_get_error (fd, &err, &len);
         if (!_lm_sock_is_blocking_error (err)) {

--- a/loudmouth/lm-proxy.c
+++ b/loudmouth/lm-proxy.c
@@ -218,12 +218,12 @@ _lm_proxy_connect_cb (GIOChannel *source, GIOCondition condition, gpointer data)
 
     g_return_val_if_fail (proxy != NULL, FALSE);
 
-    if (condition == G_IO_ERR) {
+    if (condition & G_IO_ERR) {
         len = sizeof (error);
         _lm_sock_get_error (connect_data->fd, &error, &len);
         _lm_old_socket_failed_with_error (connect_data, error);
         return FALSE;
-    } else if (condition == G_IO_OUT) {
+    } else if (condition & G_IO_OUT) {
         if (!proxy_negotiate (lm_connection_get_proxy (connection), connect_data->fd, lm_connection_get_server (connection), lm_connection_get_port (connection))) {
             _lm_old_socket_failed (connect_data);
             return FALSE;


### PR DESCRIPTION
GLib documentation [states](https://developer.gnome.org/glib/2.56/glib-IO-Channels.html#GIOCondition) that `GIOCondition` is a bitwise combination of several enum values (`G_IO_IN`, `G_IO_ERR`, etc.)  Meanwhile, `GIOChannel` callbacks used by Loudmouth (`socket_connect_cb()`, `_lm_proxy_connect_cb()`) use equality tests when processing such values.  This is wrong since a test like `if (condition == G_IO_ERR)` will fail to detect an error if the `condition` value is a bitwise combination (e.g. `G_IO_OUT | G_IO_ERR`).

In the case of MCabber, this causes failed connection attempts (e.g. refused connections, timeouts) to be treated as successful connections, which is not just confusing, but breaks i.a. reconnection attempts (since `lm_connection_open()` returns `true`, but `connection_open_cb()` is never called because the connection is torn down inside Loudmouth, in `connection_socket_connect_cb()`, since it attempts to send data over a socket which has not been successfully connected).

Apparently things have been this way since forever as the first commit I can find that contains a faulty test like this is bb8d1709674e7be2c3e16d646d01912ffd23c430, which dates back to 2004.  As far as I can tell, GLib docs for `GIOCondition` have not changed since GLib 2.0 was released back in 2002.  Perhaps GLib's internal behavior changed somewhere along the line, but I could not cause any recent GLib version to call a `GIOChannel` callback with just `G_IO_ERR` as the second parameter.
