### PR TITLE
Move away from g_type_class_add_private()

### DIFF
--- a/loudmouth/lm-blocking-resolver.c
+++ b/loudmouth/lm-blocking-resolver.c
@@ -38,10 +38,10 @@
 
 #define SRV_LEN 8192
 
-#define GET_PRIV(obj) (G_TYPE_INSTANCE_GET_PRIVATE ((obj), LM_TYPE_BLOCKING_RESOLVER, LmBlockingResolverPriv))
+#define GET_PRIV(obj) (lm_blocking_resolver_get_instance_private (LM_BLOCKING_RESOLVER(obj)))
 
-typedef struct LmBlockingResolverPriv LmBlockingResolverPriv;
-struct LmBlockingResolverPriv {
+typedef struct LmBlockingResolverPrivate LmBlockingResolverPrivate;
+struct LmBlockingResolverPrivate {
     GSource *idle_source;
 };
 
@@ -49,7 +49,7 @@ static void     blocking_resolver_dispose     (GObject       *object);
 static void     blocking_resolver_lookup      (LmResolver    *resolver);
 static void     blocking_resolver_cancel      (LmResolver    *resolver);
 
-G_DEFINE_TYPE (LmBlockingResolver, lm_blocking_resolver, LM_TYPE_RESOLVER)
+G_DEFINE_TYPE_WITH_PRIVATE (LmBlockingResolver, lm_blocking_resolver, LM_TYPE_RESOLVER)
 
 static void
 lm_blocking_resolver_class_init (LmBlockingResolverClass *class)
@@ -61,9 +61,6 @@ lm_blocking_resolver_class_init (LmBlockingResolverClass *class)
 
     resolver_class->lookup = blocking_resolver_lookup;
     resolver_class->cancel = blocking_resolver_cancel;
-
-    g_type_class_add_private (object_class,
-                              sizeof (LmBlockingResolverPriv));
 }
 
 static void
@@ -191,7 +188,7 @@ blocking_resolver_lookup_service (LmBlockingResolver *resolver)
 static gboolean
 blocking_resolver_idle_lookup (LmBlockingResolver *resolver)
 {
-    LmBlockingResolverPriv *priv = GET_PRIV (resolver);
+    LmBlockingResolverPrivate *priv = GET_PRIV (resolver);
     gint                    type;
 
     /* Start the DNS querying */
@@ -216,7 +213,7 @@ blocking_resolver_idle_lookup (LmBlockingResolver *resolver)
 static void
 blocking_resolver_lookup (LmResolver *resolver)
 {
-    LmBlockingResolverPriv *priv;
+    LmBlockingResolverPrivate *priv;
     GMainContext           *context;
 
     g_return_if_fail (LM_IS_BLOCKING_RESOLVER (resolver));
@@ -233,7 +230,7 @@ blocking_resolver_lookup (LmResolver *resolver)
 static void
 blocking_resolver_cancel (LmResolver *resolver)
 {
-    LmBlockingResolverPriv *priv;
+    LmBlockingResolverPrivate *priv;
 
     g_return_if_fail (LM_IS_BLOCKING_RESOLVER (resolver));
 

--- a/loudmouth/lm-feature-ping.c
+++ b/loudmouth/lm-feature-ping.c
@@ -28,10 +28,10 @@
 
 #define XMPP_NS_PING "urn:xmpp:ping"
 
-#define GET_PRIV(obj) (G_TYPE_INSTANCE_GET_PRIVATE ((obj), LM_TYPE_FEATURE_PING, LmFeaturePingPriv))
+#define GET_PRIV(obj) (lm_feature_ping_get_instance_private (LM_FEATURE_PING(obj)))
 
-typedef struct LmFeaturePingPriv LmFeaturePingPriv;
-struct LmFeaturePingPriv {
+typedef struct LmFeaturePingPrivate LmFeaturePingPrivate;
+struct LmFeaturePingPrivate {
     LmConnection *connection;
     guint         keep_alive_rate;
     GSource      *keep_alive_source;
@@ -55,7 +55,7 @@ feature_ping_keep_alive_reply                    (LmMessageHandler *handler,
                                                   gpointer          user_data);
 static gboolean feature_ping_send_keep_alive     (LmFeaturePing    *fp);
 
-G_DEFINE_TYPE (LmFeaturePing, lm_feature_ping, G_TYPE_OBJECT)
+G_DEFINE_TYPE_WITH_PRIVATE (LmFeaturePing, lm_feature_ping, G_TYPE_OBJECT)
 
 enum {
     PROP_0,
@@ -103,8 +103,6 @@ lm_feature_ping_class_init (LmFeaturePingClass *class)
                       NULL, NULL,
                       _lm_marshal_VOID__VOID,
                       G_TYPE_NONE, 0);
-
-    g_type_class_add_private (object_class, sizeof (LmFeaturePingPriv));
 }
 
 static void
@@ -127,7 +125,7 @@ feature_ping_get_property (GObject    *object,
                            GValue     *value,
                            GParamSpec *pspec)
 {
-    LmFeaturePingPriv *priv;
+    LmFeaturePingPrivate *priv;
 
     priv = GET_PRIV (object);
 
@@ -147,7 +145,7 @@ feature_ping_set_property (GObject      *object,
                            const GValue *value,
                            GParamSpec   *pspec)
 {
-    LmFeaturePingPriv *priv;
+    LmFeaturePingPrivate *priv;
 
     priv = GET_PRIV (object);
 
@@ -171,7 +169,7 @@ feature_ping_keep_alive_reply (LmMessageHandler *handler,
                                LmMessage        *m,
                                gpointer          user_data)
 {
-    LmFeaturePingPriv *priv;
+    LmFeaturePingPrivate *priv;
 
     priv = GET_PRIV (user_data);
 
@@ -183,7 +181,7 @@ feature_ping_keep_alive_reply (LmMessageHandler *handler,
 static gboolean
 feature_ping_send_keep_alive (LmFeaturePing *fp)
 {
-    LmFeaturePingPriv *priv;
+    LmFeaturePingPrivate *priv;
     LmMessage         *ping;
     LmMessageNode     *ping_node;
     LmMessageHandler  *keep_alive_handler;
@@ -237,7 +235,7 @@ feature_ping_send_keep_alive (LmFeaturePing *fp)
 void
 lm_feature_ping_start (LmFeaturePing *fp)
 {
-    LmFeaturePingPriv *priv;
+    LmFeaturePingPrivate *priv;
 
     g_return_if_fail (LM_IS_FEATURE_PING (fp));
 
@@ -260,7 +258,7 @@ lm_feature_ping_start (LmFeaturePing *fp)
 void
 lm_feature_ping_stop (LmFeaturePing *fp)
 {
-    LmFeaturePingPriv *priv;
+    LmFeaturePingPrivate *priv;
 
     g_return_if_fail (LM_IS_FEATURE_PING (fp));
 

--- a/loudmouth/lm-resolver.c
+++ b/loudmouth/lm-resolver.c
@@ -36,10 +36,10 @@
 #include "lm-marshal.h"
 #include "lm-resolver.h"
 
-#define GET_PRIV(obj) (G_TYPE_INSTANCE_GET_PRIVATE ((obj), LM_TYPE_RESOLVER, LmResolverPriv))
+#define GET_PRIV(obj) (lm_resolver_get_instance_private (LM_RESOLVER(obj)))
 
-typedef struct LmResolverPriv LmResolverPriv;
-struct LmResolverPriv {
+typedef struct LmResolverPrivate LmResolverPrivate;
+struct LmResolverPrivate {
     GMainContext       *context;
 
     LmResolverCallback  callback;
@@ -72,7 +72,7 @@ static void     resolver_set_property        (GObject           *object,
                                               const GValue      *value,
                                               GParamSpec        *pspec);
 
-G_DEFINE_TYPE (LmResolver, lm_resolver, G_TYPE_OBJECT)
+G_DEFINE_TYPE_WITH_PRIVATE (LmResolver, lm_resolver, G_TYPE_OBJECT)
 
 enum {
     PROP_0,
@@ -153,8 +153,6 @@ lm_resolver_class_init (LmResolverClass *class)
                                                           "Protocol for SRV lookup",
                                                           NULL,
                                                           G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
-
-    g_type_class_add_private (object_class, sizeof (LmResolverPriv));
 }
 
 static void
@@ -165,7 +163,7 @@ lm_resolver_init (LmResolver *resolver)
 static void
 resolver_dispose (GObject *object)
 {
-    LmResolverPriv *priv = GET_PRIV (object);
+    LmResolverPrivate *priv = GET_PRIV (object);
 
     if (priv->context) {
         g_main_context_unref (priv->context);
@@ -178,7 +176,7 @@ resolver_dispose (GObject *object)
 static void
 resolver_finalize (GObject *object)
 {
-    LmResolverPriv *priv;
+    LmResolverPrivate *priv;
 
     priv = GET_PRIV (object);
 
@@ -200,7 +198,7 @@ resolver_get_property (GObject    *object,
                        GValue     *value,
                        GParamSpec *pspec)
 {
-    LmResolverPriv *priv;
+    LmResolverPrivate *priv;
 
     priv = GET_PRIV (object);
 
@@ -238,7 +236,7 @@ resolver_set_property (GObject      *object,
                        const GValue *value,
                        GParamSpec   *pspec)
 {
-    LmResolverPriv *priv;
+    LmResolverPrivate *priv;
 
     priv = GET_PRIV (object);
 
@@ -311,7 +309,7 @@ lm_resolver_new_for_host (const gchar        *host,
                           gpointer            user_data)
 {
     LmResolver     *resolver;
-    LmResolverPriv *priv;
+    LmResolverPrivate *priv;
 
     g_return_val_if_fail (host != NULL, NULL);
     g_return_val_if_fail (callback != NULL, NULL);
@@ -337,7 +335,7 @@ lm_resolver_new_for_service (const gchar        *domain,
                              gpointer            user_data)
 {
     LmResolver     *resolver;
-    LmResolverPriv *priv;
+    LmResolverPrivate *priv;
 
     g_return_val_if_fail (domain != NULL, NULL);
     g_return_val_if_fail (service != NULL, NULL);
@@ -383,7 +381,7 @@ lm_resolver_cancel (LmResolver *resolver)
 struct addrinfo *
 lm_resolver_results_get_next (LmResolver *resolver)
 {
-    LmResolverPriv  *priv;
+    LmResolverPrivate  *priv;
     struct addrinfo *ret_val;
 
     g_return_val_if_fail (LM_IS_RESOLVER (resolver), NULL);
@@ -411,7 +409,7 @@ skipresult:
 void
 lm_resolver_results_reset (LmResolver *resolver)
 {
-    LmResolverPriv *priv;
+    LmResolverPrivate *priv;
 
     g_return_if_fail (LM_IS_RESOLVER (resolver));
 
@@ -437,7 +435,7 @@ _lm_resolver_set_result (LmResolver       *resolver,
                          LmResolverResult  result,
                          struct addrinfo  *results)
 {
-    LmResolverPriv *priv;
+    LmResolverPrivate *priv;
 
     g_return_if_fail (LM_IS_RESOLVER (resolver));
 


### PR DESCRIPTION
`g_type_class_add_private()` [will be deprecated in GLib 2.58](https://gitlab.gnome.org/GNOME/glib/commit/7e5db31d36532274c2b2428ef9bace796928785e).  Replace:

 - `g_type_class_add_private()` with [`G_DEFINE_TYPE_WITH_PRIVATE()`](https://developer.gnome.org/gobject/2.56/gobject-Type-Information.html#G-DEFINE-TYPE-WITH-PRIVATE:CAPS)
 - `G_TYPE_INSTANCE_GET_PRIVATE()` with `*_get_instance_private()`
