### PR TITLE
Fix falling back to another resolver result when connecting

### DIFF
--- a/loudmouth/lm-old-socket.c
+++ b/loudmouth/lm-old-socket.c
@@ -529,8 +529,8 @@ socket_connect_cb (GIOChannel   *source,
              * from it (by connecting to the next host) */
             if (!_lm_old_socket_failed_with_error (connect_data, err)) {
                 socket->watch_connect = NULL;
-                goto out;
             }
+            goto out;
         }
     }
 


### PR DESCRIPTION
If connecting to the first socket address provided by the resolver fails, `_lm_old_socket_failed_with_error()` is called, which causes the next resolver result to be tried.  However, the `goto` statement following the `_lm_old_socket_failed_with_error()` call is misplaced: if there is another resolver result available and initiating a connection to it succeeds, the `goto` statement will *not* be reached and this situation will be treated as a successful connection to the *first* resolver result.  This breaks reconnections for XMPP domains with multiple server addresses available.