### PR TITLE
lm-resolver.c: limit conditional include to OS X

### DIFF
--- a/loudmouth/lm-resolver.c
+++ b/loudmouth/lm-resolver.c
@@ -21,7 +21,7 @@
 #include <string.h>
 
 /* Needed on Mac OS X */
-#if HAVE_ARPA_NAMESER_COMPAT_H
+#if defined(__APPLE__) && HAVE_ARPA_NAMESER_COMPAT_H
 #include <arpa/nameser_compat.h>
 #endif
 


### PR DESCRIPTION
Explicitly including arpa/nameser_compat.h is only necessary for OS X.
It's unneeded on other OSes. Some, e.g. Linux and NetBSD, include
nameser_compat.h from nameser.h anyway, so at minimum, it's redundant.
In the case of NetBSD, this was causing build breakages on some
architectures due to legacy code in nameser_compat.h being exposed
before the inclusion of nameser.h, which sets dependent macros.